### PR TITLE
Increase max buffer size to 10MB

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const del = require('del');
 
 const exec = util.promisify(childProcess.exec);
 
-const TEN_MEGABYTES = 1000 * 1000 * 10;
+const tenMegabytes = 1000 * 1000 * 10;
 
 const fresh = async (cwd) => {
     const dir = await pkgDir(cwd);
@@ -19,7 +19,7 @@ const fresh = async (cwd) => {
     });
     await exec('npm install', {
         cwd       : dir,
-        maxBuffer : TEN_MEGABYTES
+        maxBuffer : tenMegabytes
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const del = require('del');
 
 const exec = util.promisify(childProcess.exec);
 
+const TEN_MEGABYTES = 1000 * 1000 * 10;
+
 const fresh = async (cwd) => {
     const dir = await pkgDir(cwd);
     if (!dir) {
@@ -16,7 +18,8 @@ const fresh = async (cwd) => {
         cwd : dir
     });
     await exec('npm install', {
-        cwd : dir
+        cwd       : dir,
+        maxBuffer : TEN_MEGABYTES
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -68,17 +68,6 @@
         "reproducible"
     ],
     "xo": {
-        "extend": "tidy",
-        "overrides": [
-            {
-                "files": "index.js",
-                "rules": {
-                    "id-match": [
-                        "error",
-                        "^[a-zA-Z_$][a-zA-Z\\d_]*$"
-                    ]
-                }
-            }
-]
+        "extend": "tidy"
     }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,17 @@
         "reproducible"
     ],
     "xo": {
-        "extend": "tidy"
+        "extend": "tidy",
+        "overrides": [
+            {
+                "files": "index.js",
+                "rules": {
+                    "id-match": [
+                        "error",
+                        "^[a-zA-Z_$][a-zA-Z\\d_]*$"
+                    ]
+                }
+            }
+]
     }
 }


### PR DESCRIPTION
I had hard times to typing `rm -rf node_modules` wait and then `npm i` because `stdout` from some modules were bigger then default `200kb` so I copied sizes from [execa](https://github.com/sindresorhus/execa) Now it `10mb`